### PR TITLE
Fix for .onUnload function.

### DIFF
--- a/OCAPIS/R/onLoad.R
+++ b/OCAPIS/R/onLoad.R
@@ -49,5 +49,5 @@
     packageStartupMessage("This is OCAPIS V.1.0.0")
 }
 .onUnload <- function(libpath) {
-  scalaPackageUnload()
+  close(s)
 }


### PR DESCRIPTION
The scalaPackageUnload will be deprecated.  Now you simply call close on the Scala bridge in the .onUnload function.